### PR TITLE
Update w5300.c

### DIFF
--- a/Ethernet/W5300/w5300.c
+++ b/Ethernet/W5300/w5300.c
@@ -212,7 +212,9 @@ void wiz_recv_data(uint8_t sn, uint8_t *wizdata, uint32_t len)
       }
       else  wizdata[i] = (uint8_t)rd;  // For checking the memory access violation
    }
-   sock_remained_byte[sn] = (uint8_t)rd; // back up the remaind fifo byte.
+   sock_remained_byte[sn] = (uint8_t)rd & 0x00FFu; // back up the remaind fifo byte.
+                              // If you use 16 bit process, perhaps, It should be recv buffer error
+                              // I think it should be inclue the mask LSB.
 }
 
 void wiz_recv_ignore(uint8_t sn, uint32_t len)


### PR DESCRIPTION
16비트 프로세스에서 LSB 한바이트를 마스킹 하지 않으면 
recv시 buf에 데이터가 이상하게 저장됨